### PR TITLE
Update NAMESPACE to address CRAN issue

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,2 +1,3 @@
 export(gsa.read.gatkreport)
 export(gsa.reshape.concordance.table)
+importFrom("utils", "type.convert")


### PR DESCRIPTION
CRAN said:

````
Version: 2.1
Check: R code for possible problems
Result: NOTE
    .gsa.assignGATKTableToEnvironment: no visible global function
     definition for 'type.convert'
    Undefined global functions or variables:
     type.convert
    Consider adding
     importFrom("utils", "type.convert")
    to your NAMESPACE file.
````

So I did